### PR TITLE
Support for docker --build-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The config file is a YAML file with the following keys:
     - `name`: The name of the app in Marathon.
     - `dir`: Path to the directory that contains the relevant Dockerfile. This can either be an absolute path or be relative to the config file itself. Defaults to the same value of `name`.
     - `glob`: An array of glob patterns to monitor for file changes inside `dir`. Defaults to an array with a single element `**/*` (i.e. all files are monitored).
-- `env`: docker build-time variables (passed to docker build with `--build-arg` option)
+- `buildArgs`: docker build-time variables (passed to docker build with `--build-arg` option)
 
 If an element in `apps` is a string it will be regarded the same as an object with that string value in both `name` and `dir`. This means:
 
@@ -103,7 +103,7 @@ apps:
   - **/*.js
   - **/*.css
   - **/*.html
-env:
+buildArgs:
   NPM_TOKEN: 2323drff98-41c8-3c05-2342-237821hd
   DOCKER_BUILD_ARG: docker-build-arg
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The config file is a YAML file with the following keys:
     - `name`: The name of the app in Marathon.
     - `dir`: Path to the directory that contains the relevant Dockerfile. This can either be an absolute path or be relative to the config file itself. Defaults to the same value of `name`.
     - `glob`: An array of glob patterns to monitor for file changes inside `dir`. Defaults to an array with a single element `**/*` (i.e. all files are monitored).
+- `env`: docker build-time variables (passed to docker build with `--build-arg` option)
 
 If an element in `apps` is a string it will be regarded the same as an object with that string value in both `name` and `dir`. This means:
 
@@ -102,6 +103,9 @@ apps:
   - **/*.js
   - **/*.css
   - **/*.html
+env:
+  NPM_TOKEN: 2323drff98-41c8-3c05-2342-237821hd
+  DOCKER_BUILD_ARG: docker-build-arg
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "promise-queue": "^2.2.0",
     "request-promise": "^1.0.2",
     "sane": "^1.0.3",
+    "shell-escape-tag": "^1.1.0",
     "yargs": "^3.29.0"
   },
   "devDependencies": {

--- a/src/start.js
+++ b/src/start.js
@@ -18,7 +18,7 @@ export default async function() {
 
     let config = getConfig()
     await promiseMapSeries(config.apps, app => {
-        let watcher = new Watcher(app, config.env)
+        let watcher = new Watcher(app, config.buildArgs)
         return watcher.watch()
     })
 }

--- a/src/start.js
+++ b/src/start.js
@@ -16,8 +16,9 @@ export default async function() {
         process.exit(1)
     }
 
-    await promiseMapSeries(getConfig().apps, app => {
-        let watcher = new Watcher(app)
+    let config = getConfig()
+    await promiseMapSeries(config.apps, app => {
+        let watcher = new Watcher(app, config.env)
         return watcher.watch()
     })
 }

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -8,9 +8,9 @@ import {updateApp} from './marathon'
 import {get as getConfig} from './config'
 
 export default class Watcher {
-    constructor(app, env) {
+    constructor(app, buildArgs) {
         this.app = app
-        this.env = env
+        this.buildArgs = buildArgs
 
     	this.restarting = false
     	this.again = false
@@ -60,7 +60,7 @@ export default class Watcher {
             let imageName = getConfig().registry + `/${this.app.name}:${tag}`
             this.log(`Building image ${imageName}`)
             let params = ['build', '-t', imageName, '.']
-            _.map(this.env, (value, key) => {
+            _.map(this.buildArgs, (value, key) => {
                 params.push('--build-arg')
                 params.push(`${key}="${value}"`)
             })

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -6,6 +6,7 @@ import hostExec from './host-exec'
 import queue from './queue'
 import {updateApp} from './marathon'
 import {get as getConfig} from './config'
+import shell from 'shell-escape-tag'
 
 export default class Watcher {
     constructor(app, buildArgs) {
@@ -62,7 +63,7 @@ export default class Watcher {
             let params = ['build', '-t', imageName, '.']
             _.map(this.buildArgs, (value, key) => {
                 params.push('--build-arg')
-                params.push(`${key}="${value}"`)
+                params.push(shell`${key}=${value}`)
             })
             await hostExec('docker', params, {cwd: this.app.dir})
             this.log('Pushing image')

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -8,8 +8,9 @@ import {updateApp} from './marathon'
 import {get as getConfig} from './config'
 
 export default class Watcher {
-    constructor(app) {
+    constructor(app, env) {
         this.app = app
+        this.env = env
 
     	this.restarting = false
     	this.again = false
@@ -58,7 +59,12 @@ export default class Watcher {
             let tag = this.app.tag || getConfig().tag || 'orca.' + Date.now() //We append a timestamp since we want to make sure Marathon pulls the new image
             let imageName = getConfig().registry + `/${this.app.name}:${tag}`
             this.log(`Building image ${imageName}`)
-            await hostExec('docker', ['build', '-t', imageName, '.'], {cwd: this.app.dir})
+            let params = ['build', '-t', imageName, '.']
+            _.map(this.env, (value, key) => {
+                params.push('--build-arg')
+                params.push(`${key}="${value}"`)
+            })
+            await hostExec('docker', params, {cwd: this.app.dir})
             this.log('Pushing image')
             await hostExec('docker', ['push', imageName], {cwd: this.app.dir})
             this.log('Updating Marathon')


### PR DESCRIPTION
It will be so cool if orca supports docker build-args.

We use it to pass NPM credentials, so we can fetch from private npm registry on docker build.
But it can be used for anything - HTTP_PROXY, private RubyGems creds, etc.

Sky is the limit ;-)
